### PR TITLE
fix: show detailed error message

### DIFF
--- a/src/main/kotlin/com/ypwang/plugin/GoLinterExternalAnnotator.kt
+++ b/src/main/kotlin/com/ypwang/plugin/GoLinterExternalAnnotator.kt
@@ -493,7 +493,7 @@ class GoLinterExternalAnnotator : ExternalAnnotator<PsiFile, GoLinterExternalAnn
                         else ->
                             notificationGroup.createNotification(
                                     ErrorTitle,
-                                    "Please make sure no syntax or config error, then run 'go mod tidy' to ensure deps ok",
+                                    processResult.stderr,
                                     NotificationType.WARNING).apply {
                                 this.addAction(NotificationAction.createSimple("Configure") {
                                     ShowSettingsUtil.getInstance().editConfigurable(project, GoLinterConfigurable(project))


### PR DESCRIPTION
When an unknown error is raised, show details error msg instead of "Please make sure..."

For #119 and #122 

Example:
![image](https://github.com/xxpxxxxp/intellij-plugin-golangci-lint/assets/50364282/02e1bb41-a974-4a00-ade3-69f36b887668)
