### PR TITLE
fix the problem of empty env variables on macOS

### DIFF
--- a/src/main/kotlin/com/ypwang/plugin/platform/Platform.kt
+++ b/src/main/kotlin/com/ypwang/plugin/platform/Platform.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.util.EnvironmentUtil
 import com.ypwang.plugin.*
 import com.ypwang.plugin.model.GithubRelease
 import com.ypwang.plugin.model.RunProcessResult
@@ -90,6 +91,15 @@ abstract class Platform(protected val project: Project) {
             if (path.isNotBlank())
                 // system path itself is absolute for running OS
                 rst.add(path)
+
+            // try to fix macOS empty system environment variables, read environment variables from .zshrc or .bashrc
+            // see: https://github.com/JetBrains/intellij-community/blob/master/platform/util/src/com/intellij/util/EnvironmentUtil.java#L72
+            if (SystemInfo.isMac) {
+                val systemEnvPath = EnvironmentUtil.getValue(Const_Path) ?: ""
+                if (systemEnvPath.isNotBlank()) {
+                    rst.add(systemEnvPath)
+                }
+            }
 
             return rst
         }


### PR DESCRIPTION
I found a problem that the plugin cannot read the executable file path on macOS, even if this path is configured in the .zshrc file. Because IDEA launched by a GUI launcher (Finder, Dock, Spotlight etc.) cannot receive  the environment variables on the .bashrc or .bashrc.  see more info: https://github.com/JetBrains/intellij-community/blob/master/platform/util/src/com/intellij/util/EnvironmentUtil.java#L73C71-L73C118